### PR TITLE
Fix linking on Linux

### DIFF
--- a/libsoundio-sys/build.rs
+++ b/libsoundio-sys/build.rs
@@ -104,7 +104,7 @@ fn main() {
     }
 
     // Link soundio.
-    println!("cargo:rustc-link-lib=static=soundio");
+    println!("cargo:rustc-link-lib=soundio");
 
     // OSX
     if target.contains("apple") {


### PR DESCRIPTION
This fixes the following error when building `psst`:
> could not find native static library `soundio`, perhaps an -L flag is missing?

Not sure if this still works under Windows, since I cannot test it. 